### PR TITLE
Tracker: time-delayed re_id added; TrackedObject: tracking_score added

### DIFF
--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -98,3 +98,20 @@ def warn_once(message):
     Write a warning message only once.
     """
     warn(message)
+
+
+#  for each row of a numpy matrix finds difference between its two smallest elements.
+def difference_between_smallest(matrix):
+    differences = []
+
+    for row in matrix:
+        # Use numpy's partition function to partially sort the array.
+        # This makes it efficient to retrieve the smallest and second smallest elements.
+        if len(row) > 1:
+            smallest_two = np.partition(row, 1)[:2]
+            diff = np.abs(smallest_two[1] - smallest_two[0])
+            differences.append(diff)
+        else:
+            differences.append(np.inf)
+
+    return differences


### PR DESCRIPTION
https://degirum.atlassian.net/browse/SD-950

1. A new property tracking_score is added to TrackedObject. It is set to 0 for new objects, but changes to 1 for well-tracked objects. If other tracked objects are close enough (like in the case of occlusion), this value is decreased again. The client of norfair tracking can use this value for making the decision to reid the tracked object by computing embeddings and establishing object_id.  

2. Suppose we have a TrackedObject with some global_id. We compute asychronously embeddings and object_id of that object. When the results are available, the new Detection, holding this global_id and new object_id can be passed to Tracker via the new re_id method. At this moment, Tracker updates corresponding TrackerObject with new object_id.   

Both improvements are successfully used in current version of [dg_face_tracker](https://github.com/DeGirum/dg_face_tracking) demo